### PR TITLE
Submodule/Embeded Usage Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@
 
 .clangd
 build
+
+.vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 
 project(hass_mqtt_device VERSION 0.0.1 LANGUAGES CXX)
 
+option(HASS_MQTT_DEVICE_EXAMPLES "Build Examples" OFF)
+
 # Assume that we are on rPi if it is an arm variant
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
     add_definitions(-DARM_ARCH)
@@ -65,11 +67,13 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION include)
 #    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests
 #)
 
-# For examples
-# add_subdirectory(examples)
+if(HASS_MQTT_DEVICE_EXAMPLES)
+    # For examples
+    add_subdirectory(examples)
 
-# Create a custom target for building examples
-#add_custom_target(examples
-#    COMMAND ${CMAKE_COMMAND} --build . --target all
-#    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/examples
-#)
+    # Create a custom target for building examples
+    add_custom_target(examples
+        COMMAND ${CMAKE_COMMAND} --build . --target all
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/examples
+    )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,18 +16,18 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 endif()
 
-# Specify the required C++ standard
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-
 # Source files
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
 # Create the library
 add_library(hass_mqtt_device SHARED ${SOURCES})
+set_target_properties(hass_mqtt_device PROPERTIES
+    # Specify the required C++ standard
+    CXX_STANDARD 17
+)
 
 # Compiler flags
-target_compile_options(hass_mqtt_device PRIVATE 
+target_compile_options(hass_mqtt_device PRIVATE
   $<$<CONFIG:Debug>:-g3 -O0>
   $<$<CONFIG:Release>:-O3>
 )
@@ -39,7 +39,7 @@ if(CCACHE_PROGRAM)
 endif()
 
 # Include directories
-target_include_directories(hass_mqtt_device PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(hass_mqtt_device PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(hass_mqtt_device PUBLIC ${MOSQUITTO_INCLUDE_DIRS})
 
 # Find required libraries
@@ -52,7 +52,7 @@ target_link_libraries(hass_mqtt_device ${MOSQUITTO_LIBRARIES} spdlog::spdlog)
 
 # Specify where the library should be installed
 install(TARGETS hass_mqtt_device DESTINATION lib)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION include)
 
 # For tests, you can use CTest
 #enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 project(hass_mqtt_device VERSION 0.0.1 LANGUAGES CXX)
 
 option(HASS_MQTT_DEVICE_EXAMPLES "Build Examples" OFF)
+option(HASS_MQTT_DEVICE_STATIC "Build as a static lib" OFF)
 
 # Assume that we are on rPi if it is an arm variant
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
@@ -22,7 +23,11 @@ endif()
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
 # Create the library
-add_library(hass_mqtt_device SHARED ${SOURCES})
+if(HASS_MQTT_DEVICE_STATIC)
+    add_library(hass_mqtt_device STATIC ${SOURCES})
+else()
+    add_library(hass_mqtt_device SHARED ${SOURCES})
+endif()
 set_target_properties(hass_mqtt_device PROPERTIES
     # Specify the required C++ standard
     CXX_STANDARD 17

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,15 @@ target_include_directories(hass_mqtt_device PUBLIC ${MOSQUITTO_INCLUDE_DIRS})
 # Find required libraries
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(MOSQUITTO REQUIRED libmosquitto)
-find_package(spdlog REQUIRED)
+find_package(spdlog)
 find_package(nlohmann_json REQUIRED)
 
 # Link libraries
-target_link_libraries(hass_mqtt_device ${MOSQUITTO_LIBRARIES} spdlog::spdlog nlohmann_json::nlohmann_json)
+target_link_libraries(hass_mqtt_device ${MOSQUITTO_LIBRARIES} nlohmann_json::nlohmann_json)
+if(spdlog_FOUND)
+    target_link_libraries(hass_mqtt_device spdlog::spdlog)
+endif()
+
 
 # Specify where the library should be installed
 install(TARGETS hass_mqtt_device DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(hass_mqtt_device ${MOSQUITTO_LIBRARIES} nlohmann_json::nlo
 
 if(HASS_MQTT_DEVICE_SPDLOG)
     find_package(spdlog)
+    add_definitions(-DHASS_MQTT_DEVICE_SPDLOG)
     if(spdlog_FOUND)
         target_link_libraries(hass_mqtt_device spdlog::spdlog)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(hass_mqtt_device VERSION 0.0.1 LANGUAGES CXX)
 
 option(HASS_MQTT_DEVICE_EXAMPLES "Build Examples" OFF)
 option(HASS_MQTT_DEVICE_STATIC "Build as a static lib" OFF)
+option(HASS_MQTT_DEVICE_SPDLOG "Use SPDLOG lib" ON)
 
 # Assume that we are on rPi if it is an arm variant
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
@@ -52,13 +53,16 @@ target_include_directories(hass_mqtt_device PUBLIC ${MOSQUITTO_INCLUDE_DIRS})
 # Find required libraries
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(MOSQUITTO REQUIRED libmosquitto)
-find_package(spdlog)
 find_package(nlohmann_json REQUIRED)
 
 # Link libraries
 target_link_libraries(hass_mqtt_device ${MOSQUITTO_LIBRARIES} nlohmann_json::nlohmann_json)
-if(spdlog_FOUND)
-    target_link_libraries(hass_mqtt_device spdlog::spdlog)
+
+if(HASS_MQTT_DEVICE_SPDLOG)
+    find_package(spdlog)
+    if(spdlog_FOUND)
+        target_link_libraries(hass_mqtt_device spdlog::spdlog)
+    endif()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,9 +46,10 @@ target_include_directories(hass_mqtt_device PUBLIC ${MOSQUITTO_INCLUDE_DIRS})
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(MOSQUITTO REQUIRED libmosquitto)
 find_package(spdlog REQUIRED)
+find_package(nlohmann_json REQUIRED)
 
 # Link libraries
-target_link_libraries(hass_mqtt_device ${MOSQUITTO_LIBRARIES} spdlog::spdlog)
+target_link_libraries(hass_mqtt_device ${MOSQUITTO_LIBRARIES} spdlog::spdlog nlohmann_json::nlohmann_json)
 
 # Specify where the library should be installed
 install(TARGETS hass_mqtt_device DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,10 +65,10 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION include)
 #)
 
 # For examples
-add_subdirectory(examples)
+# add_subdirectory(examples)
 
 # Create a custom target for building examples
-add_custom_target(examples
-    COMMAND ${CMAKE_COMMAND} --build . --target all
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/examples
-)
+#add_custom_target(examples
+#    COMMAND ${CMAKE_COMMAND} --build . --target all
+#    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/examples
+#)

--- a/include/hass_mqtt_device/logger/logger.hpp
+++ b/include/hass_mqtt_device/logger/logger.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#if __has_include(<spdlog/spdlog.h>)
+#if __has_include(<spdlog/spdlog.h>) && defined(HASS_MQTT_DEVICE_SPDLOG)
 
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>

--- a/include/hass_mqtt_device/logger/logger.hpp
+++ b/include/hass_mqtt_device/logger/logger.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#if __has_include(<spdlog/spdlog.h>)
+
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
@@ -21,3 +23,14 @@
 #define LOG_ERROR(...) spdlog::error(__VA_ARGS__)
 #define LOG_DEBUG(...) spdlog::debug(__VA_ARGS__)
 #define LOG_TRACE(...) spdlog::trace(__VA_ARGS__)
+
+#else
+
+#define INIT_LOGGER(debug)
+#define LOG_INFO(...)
+#define LOG_WARN(...)
+#define LOG_ERROR(...)
+#define LOG_DEBUG(...)
+#define LOG_TRACE(...)
+
+#endif


### PR DESCRIPTION
Hi,

I started using this library in my [shmuelie/mfi-custom-code](https://github.com/shmuelie/mfi-custom-code) repo and had to make some changes to it that I thought might be worth adding upstream.

- Added options to the CMakeLists.txt to support
  - Disabling Examples
  - Building as a static library
  - Not using Spdlog
- Change how sources are added to support being a submodule of another project
- Added `nlohmann_json` to the list of packages to find and link
- Changes to support not using Spdlog